### PR TITLE
[FLINK-XXXX] Introduce ClusterOptions.PROCESS_WORKING_DIR_BASE for configuring a process directory

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -80,5 +80,23 @@
             <td>Boolean</td>
             <td>Whether to convert all PIPELINE edges to BLOCKING when apply fine-grained resource management in batch jobs.</td>
         </tr>
+        <tr>
+            <td><h5>process.jobmanager.working-dir</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Working directory for the JobManager process. The working directory can be used to store information that can be used upon process recovery.</td>
+        </tr>
+        <tr>
+            <td><h5>process.taskmanager.working-dir</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Working directory for the TaskManager process. The working directory can be used to store information that can be used upon process recovery.</td>
+        </tr>
+        <tr>
+            <td><h5>process.working-dir</h5></td>
+            <td style="word-wrap: break-word;">"/var/folders/ck/2gym0wnn4cg48v53_t2slm4r0000gn/T/"</td>
+            <td>String</td>
+            <td>Working directory for Flink processes. The working directory can be used to store information that can be used upon process recovery. If the not configured, then it will default to <code class="highlighter-rouge">System.getProperty("java.io.tmpdir")</code>.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -26,5 +26,23 @@
             <td><p>Enum</p></td>
             <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)<br /><br />Possible values:<ul><li>"LOG"</li><li>"FAIL"</li></ul></td>
         </tr>
+        <tr>
+            <td><h5>process.jobmanager.working-dir</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Working directory for the JobManager process. The working directory can be used to store information that can be used upon process recovery.</td>
+        </tr>
+        <tr>
+            <td><h5>process.taskmanager.working-dir</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Working directory for the TaskManager process. The working directory can be used to store information that can be used upon process recovery.</td>
+        </tr>
+        <tr>
+            <td><h5>process.working-dir</h5></td>
+            <td style="word-wrap: break-word;">"/var/folders/ck/2gym0wnn4cg48v53_t2slm4r0000gn/T/"</td>
+            <td>String</td>
+            <td>Working directory for Flink processes. The working directory can be used to store information that can be used upon process recovery. If the not configured, then it will default to <code class="highlighter-rouge">System.getProperty("java.io.tmpdir")</code>.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.InlineElement;
+import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.configuration.ClusterOptions.UserSystemExitMode.THROW;
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -148,6 +149,43 @@ public class ClusterOptions {
                                             + "by just logging them (%s mode), or by failing job (%s mode)",
                                     UncaughtExceptionHandleMode.LOG.name(),
                                     UncaughtExceptionHandleMode.FAIL.name()));
+
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+    public static final ConfigOption<String> PROCESS_WORKING_DIR_BASE =
+            ConfigOptions.key("process.working-dir")
+                    .stringType()
+                    .defaultValue(System.getProperty("java.io.tmpdir"))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Working directory for Flink processes. The working directory can be used to store information that can be used upon process recovery. If the not configured, then it will default to %s.",
+                                            TextElement.code(
+                                                    "System.getProperty(\"java.io.tmpdir\")"))
+                                    .build());
+
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+    public static final ConfigOption<String> JOB_MANAGER_PROCESS_WORKING_DIR_BASE =
+            ConfigOptions.key("process.jobmanager.working-dir")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys(PROCESS_WORKING_DIR_BASE.key())
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Working directory for the JobManager process. The working directory can be used to store information that can be used upon process recovery.")
+                                    .build());
+
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+    public static final ConfigOption<String> TASK_MANAGER_PROCESS_WORKING_DIR_BASE =
+            ConfigOptions.key("process.taskmanager.working-dir")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys(PROCESS_WORKING_DIR_BASE.key())
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Working directory for the TaskManager process. The working directory can be used to store information that can be used upon process recovery.")
+                                    .build());
 
     public static JobManagerOptions.SchedulerType getSchedulerType(Configuration configuration) {
         if (isAdaptiveSchedulerEnabled(configuration) || isReactiveModeEnabled(configuration)) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptionsInternal.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptionsInternal.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+/** Internal cluster options. */
+public class ClusterOptionsInternal {
+
+    private ClusterOptionsInternal() {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Cannot instantiate %s.", ClusterOptionsInternal.class.getSimpleName()));
+    }
+
+    /** Internal option which contains the current working directory of the Flink process. */
+    public static final ConfigOption<String> WORKING_DIR =
+            ConfigOptions.key("$internal.process.working-dir")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Resolved working directory for the current process.");
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.After;
@@ -31,7 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -39,9 +39,11 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class TaskLocalStateStoreImplTest {
+/** Test for the {@link TaskLocalStateStoreImpl}. */
+public class TaskLocalStateStoreImplTest extends TestLogger {
 
     private SortedMap<Long, TaskStateSnapshot> internalSnapshotMap;
     private Object internalLock;
@@ -113,7 +115,7 @@ public class TaskLocalStateStoreImplTest {
             Assert.assertNull(taskLocalStateStore.retrieveLocalState(i));
         }
 
-        List<TaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
+        List<TestingTaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
 
         checkStoredAsExpected(taskStateSnapshots, 0, chkCount);
 
@@ -126,7 +128,7 @@ public class TaskLocalStateStoreImplTest {
 
         final int chkCount = 3;
 
-        List<TaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
+        List<TestingTaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
 
         // test retrieve with pruning
         taskLocalStateStore.pruneMatchingCheckpoints((long chk) -> chk != chkCount - 1);
@@ -144,7 +146,7 @@ public class TaskLocalStateStoreImplTest {
 
         final int chkCount = 3;
         final int confirmed = chkCount - 1;
-        List<TaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
+        List<TestingTaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
         taskLocalStateStore.confirmCheckpoint(confirmed);
         checkPrunedAndDiscarded(taskStateSnapshots, 0, confirmed);
         checkStoredAsExpected(taskStateSnapshots, confirmed, chkCount);
@@ -156,7 +158,7 @@ public class TaskLocalStateStoreImplTest {
 
         final int chkCount = 4;
         final int aborted = chkCount - 2;
-        List<TaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
+        List<TestingTaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
         taskLocalStateStore.abortCheckpoint(aborted);
         checkPrunedAndDiscarded(taskStateSnapshots, aborted, aborted + 1);
         checkStoredAsExpected(taskStateSnapshots, 0, aborted);
@@ -170,40 +172,55 @@ public class TaskLocalStateStoreImplTest {
     public void dispose() throws Exception {
         final int chkCount = 3;
         final int confirmed = chkCount - 1;
-        List<TaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
+        List<TestingTaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
         taskLocalStateStore.confirmCheckpoint(confirmed);
         taskLocalStateStore.dispose();
 
         checkPrunedAndDiscarded(taskStateSnapshots, 0, chkCount);
     }
 
-    private void checkStoredAsExpected(List<TaskStateSnapshot> history, int start, int end)
-            throws Exception {
+    private void checkStoredAsExpected(List<TestingTaskStateSnapshot> history, int start, int end) {
         for (int i = start; i < end; ++i) {
-            TaskStateSnapshot expected = history.get(i);
-            Assert.assertTrue(expected == taskLocalStateStore.retrieveLocalState(i));
-            Mockito.verify(expected, Mockito.never()).discardState();
+            TestingTaskStateSnapshot expected = history.get(i);
+            assertTrue(expected == taskLocalStateStore.retrieveLocalState(i));
+            assertFalse(expected.isDiscarded());
         }
     }
 
-    private void checkPrunedAndDiscarded(List<TaskStateSnapshot> history, int start, int end)
-            throws Exception {
+    private void checkPrunedAndDiscarded(
+            List<TestingTaskStateSnapshot> history, int start, int end) {
         for (int i = start; i < end; ++i) {
             Assert.assertNull(taskLocalStateStore.retrieveLocalState(i));
-            Mockito.verify(history.get(i)).discardState();
+            assertTrue(history.get(i).isDiscarded());
         }
     }
 
-    private List<TaskStateSnapshot> storeStates(int count) {
-        List<TaskStateSnapshot> taskStateSnapshots = new ArrayList<>(count);
+    private List<TestingTaskStateSnapshot> storeStates(int count) {
+        List<TestingTaskStateSnapshot> taskStateSnapshots = new ArrayList<>(count);
         for (int i = 0; i < count; ++i) {
             OperatorID operatorID = new OperatorID();
-            TaskStateSnapshot taskStateSnapshot = spy(new TaskStateSnapshot());
+            TestingTaskStateSnapshot taskStateSnapshot = new TestingTaskStateSnapshot();
             OperatorSubtaskState operatorSubtaskState = OperatorSubtaskState.builder().build();
             taskStateSnapshot.putSubtaskStateByOperatorID(operatorID, operatorSubtaskState);
             taskLocalStateStore.storeLocalState(i, taskStateSnapshot);
             taskStateSnapshots.add(taskStateSnapshot);
         }
         return taskStateSnapshots;
+    }
+
+    private static final class TestingTaskStateSnapshot extends TaskStateSnapshot {
+        private static final long serialVersionUID = 2046321877379917040L;
+
+        private boolean isDiscarded = false;
+
+        @Override
+        public void discardState() throws Exception {
+            super.discardState();
+            isDiscarded = true;
+        }
+
+        boolean isDiscarded() {
+            return isDiscarded;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -18,23 +18,36 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptionsInternal;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
+import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 
 import javax.annotation.Nonnull;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.concurrent.CompletableFuture;
 
@@ -42,10 +55,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link TaskManagerRunner}. */
 public class TaskManagerRunnerTest extends TestLogger {
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     @Rule public final Timeout timeout = Timeout.seconds(30);
 
@@ -189,6 +206,61 @@ public class TaskManagerRunnerTest extends TestLogger {
                 is(equalTo(TaskManagerRunner.Result.SUCCESS)));
     }
 
+    @Test
+    public void testWorkingDirIsSetupWhenStartingTaskManagerRunner() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID taskManagerResourceId = new ResourceID("foobar");
+
+        final Configuration configuration =
+                createConfigurationWithWorkingDirectory(workingDirBase, taskManagerResourceId);
+        final File workingDir =
+                ClusterEntrypointUtils.createWorkingDir(
+                        workingDirBase.getAbsolutePath(), taskManagerResourceId);
+        final TaskManagerRunner taskManagerRunner = createTaskManagerRunner(configuration);
+
+        try {
+            assertTrue(workingDir.exists());
+        } finally {
+            taskManagerRunner.close();
+        }
+
+        assertFalse(
+                "The working dir should be cleaned up when stopping the TaskManager process gracefully.",
+                workingDir.exists());
+    }
+
+    @Nonnull
+    private Configuration createConfigurationWithWorkingDirectory(
+            File workingDirBase, ResourceID taskManagerResourceId) {
+        final Configuration configuration = createConfiguration();
+
+        configuration.set(
+                ClusterOptions.PROCESS_WORKING_DIR_BASE, workingDirBase.getAbsolutePath());
+        configuration.set(
+                TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, taskManagerResourceId.toString());
+        return configuration;
+    }
+
+    @Test
+    public void testWorkingDirIsNotDeletedInCaseOfFailure() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID resourceId = ResourceID.generate();
+
+        final Configuration configuration =
+                createConfigurationWithWorkingDirectory(workingDirBase, resourceId);
+
+        final TaskManagerRunner taskManagerRunner =
+                createTaskManagerRunner(
+                        configuration, new TestingFailingTaskExecutorServiceFactory());
+
+        taskManagerRunner.getTerminationFuture().join();
+
+        assertTrue(
+                ClusterEntrypointUtils.createWorkingDir(
+                                workingDirBase.getAbsolutePath(), resourceId)
+                        .exists());
+    }
+
     @Nonnull
     private TaskManagerRunner.TaskExecutorServiceFactory createTaskExecutorServiceFactory(
             TestingTaskExecutorService taskExecutorService) {
@@ -226,5 +298,29 @@ public class TaskManagerRunnerTest extends TestLogger {
                 new TaskManagerRunner(configuration, pluginManager, taskExecutorServiceFactory);
         taskManagerRunner.start();
         return taskManagerRunner;
+    }
+
+    private static class TestingFailingTaskExecutorServiceFactory
+            implements TaskManagerRunner.TaskExecutorServiceFactory {
+        @Override
+        public TaskManagerRunner.TaskExecutorService createTaskExecutor(
+                Configuration configuration,
+                ResourceID resourceID,
+                RpcService rpcService,
+                HighAvailabilityServices highAvailabilityServices,
+                HeartbeatServices heartbeatServices,
+                MetricRegistry metricRegistry,
+                BlobCacheService blobCacheService,
+                boolean localCommunicationOnly,
+                ExternalResourceInfoProvider externalResourceInfoProvider,
+                FatalErrorHandler fatalErrorHandler) {
+            return TestingTaskExecutorService.newBuilder()
+                    .setStartRunnable(
+                            () ->
+                                    fatalErrorHandler.onFatalError(
+                                            new FlinkException(
+                                                    "Cannot instantiate the TaskExecutorService.")))
+                    .build();
+        }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -263,7 +263,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
     public abstract void testTaskManagerFailure(Configuration configuration, File coordinateDir)
             throws Exception;
 
-    protected static void printProcessLog(String processName, TestProcess process) {
+    static void printProcessLog(String processName, TestProcess process) {
         if (process == null) {
             System.out.println("-----------------------------------------");
             System.out.println(" PROCESS " + processName + " WAS NOT STARTED.");

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerRunnerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerRunnerITCase.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.recovery;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
+import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.test.util.TestProcessBuilder;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+/** Integration tests for the {@link TaskManagerRunner}. */
+public class TaskManagerRunnerITCase extends TestLogger {
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @Test
+    public void testWorkingDirIsNotDeletedInCaseOfProcessFailure() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID resourceId = ResourceID.generate();
+        final File workingDirectory =
+                ClusterEntrypointUtils.createWorkingDir(
+                        workingDirBase.getAbsolutePath(), resourceId);
+
+        final Configuration configuration = new Configuration();
+        configuration.set(
+                ClusterOptions.PROCESS_WORKING_DIR_BASE, workingDirBase.getAbsolutePath());
+        configuration.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, resourceId.toString());
+        configuration.set(JobManagerOptions.ADDRESS, "localhost");
+        configuration.set(AkkaOptions.LOOKUP_TIMEOUT_DURATION, Duration.ZERO);
+
+        final TestProcessBuilder.TestProcess taskManagerProcess =
+                new TestProcessBuilder(
+                                AbstractTaskManagerProcessFailureRecoveryTest
+                                        .TaskExecutorProcessEntryPoint.class
+                                        .getName())
+                        .addConfigAsMainClassArgs(configuration)
+                        .start();
+
+        boolean success = false;
+        try {
+            CommonTestUtils.waitUntilCondition(
+                    workingDirectory::exists, Deadline.fromNow(Duration.ofMinutes(1L)));
+
+            taskManagerProcess.getProcess().destroy();
+
+            taskManagerProcess.getProcess().waitFor();
+
+            assertTrue(workingDirectory.exists());
+            success = true;
+        } finally {
+            if (!success) {
+                AbstractTaskManagerProcessFailureRecoveryTest.printProcessLog(
+                        "TaskManager", taskManagerProcess);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the configuration option to configure a working directory for the JobManager
and TaskManager process. The resulting working directory will be <WORKING_DIR_BASE>/<RESOURCE_ID> and
will be made accessible to the Flink processes via ClusterOptionsInternal.WORKING_DIR.