### PR TITLE
[FLINK-XXXX] Make JobManager process resource id configurable via jobmanager.resource-id

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.resource-id</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The JobManager's ResourceID. If not configured, the ResourceID will be generated randomly.</td>
+        </tr>
+        <tr>
             <td><h5>task.cancellation.interval</h5></td>
             <td style="word-wrap: break-word;">30000</td>
             <td>Long</td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -117,6 +117,12 @@
             <td>Total Process Memory size for the JobManager. This includes all the memory that a JobManager JVM process consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. In containerized setups, this should be set to the container memory. See also 'jobmanager.memory.flink.size' for Total Flink Memory size configuration.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.resource-id</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The JobManager's ResourceID. If not configured, the ResourceID will be generated randomly.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.retrieve-taskmanager-hostname</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -480,6 +480,17 @@ public class JobManagerOptions {
                     .withDescription(
                             "Controls whether partitions should already be released during the job execution.");
 
+    /**
+     * The JobManager's ResourceID. If not configured, the ResourceID will be generated randomly.
+     */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<String> JOB_MANAGER_RESOURCE_ID =
+            key("jobmanager.resource-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The JobManager's ResourceID. If not configured, the ResourceID will be generated randomly.");
+
     // ---------------------------------------------------------------------------------------------
 
     private JobManagerOptions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -340,8 +340,18 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                     createSerializableExecutionGraphStore(
                             configuration, commonRpcService.getScheduledExecutor());
 
-            ClusterEntrypointUtils.configureJobManagerWorkingDirectory(
-                    configuration, ResourceID.generate());
+            final ResourceID resourceId =
+                    configuration
+                            .getOptional(JobManagerOptions.JOB_MANAGER_RESOURCE_ID)
+                            .map(ResourceID::new)
+                            .orElseGet(ResourceID::generate);
+
+            LOG.debug(
+                    "Initialize cluster entrypoint {} with resource id {}.",
+                    getClass().getSimpleName(),
+                    resourceId);
+
+            ClusterEntrypointUtils.configureJobManagerWorkingDirectory(configuration, resourceId);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.entrypoint;
 
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -67,6 +68,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -228,6 +230,80 @@ public class ClusterEntrypointTest extends TestLogger {
 
             clusterEntrypointProcess.destroy();
         }
+    }
+
+    @Test
+    public void testWorkingDirectoryIsSetupWhenStartingTheClusterEntrypoint() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID resourceId = new ResourceID("foobar");
+        final File workingDir =
+                ClusterEntrypointUtils.createWorkingDir(
+                        workingDirBase.getAbsolutePath(), resourceId);
+
+        configureWorkingDirectory(flinkConfig, workingDirBase, resourceId);
+
+        try (final TestingEntryPoint testingEntryPoint =
+                new TestingEntryPoint.Builder().setConfiguration(flinkConfig).build()) {
+            testingEntryPoint.startCluster();
+            assertTrue(workingDir.exists());
+        }
+    }
+
+    private static void configureWorkingDirectory(
+            Configuration configuration, File workingDirBase, ResourceID resourceId) {
+        configuration.set(
+                ClusterOptions.PROCESS_WORKING_DIR_BASE, workingDirBase.getAbsolutePath());
+        configuration.set(JobManagerOptions.JOB_MANAGER_RESOURCE_ID, resourceId.toString());
+    }
+
+    @Test
+    public void testWorkingDirectoryIsNotDeletedWhenStoppingClusterEntrypoint() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID resourceId = new ResourceID("foobar");
+        final File workingDir =
+                ClusterEntrypointUtils.createWorkingDir(
+                        workingDirBase.getAbsolutePath(), resourceId);
+
+        configureWorkingDirectory(flinkConfig, workingDirBase, resourceId);
+
+        try (final TestingEntryPoint testingEntryPoint =
+                new TestingEntryPoint.Builder().setConfiguration(flinkConfig).build()) {
+            testingEntryPoint.startCluster();
+        }
+
+        assertTrue(
+                "The working directory has been deleted when the cluster entrypoint shut down. This should not happen.",
+                workingDir.exists());
+    }
+
+    @Test
+    public void testWorkingDirectoryIsDeletedIfApplicationCompletes() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID resourceId = new ResourceID("foobar");
+        final File workingDir =
+                ClusterEntrypointUtils.createWorkingDir(
+                        workingDirBase.getAbsolutePath(), resourceId);
+
+        configureWorkingDirectory(flinkConfig, workingDirBase, resourceId);
+
+        final CompletableFuture<ApplicationStatus> shutDownFuture = new CompletableFuture<>();
+
+        final TestingEntryPoint testingEntryPoint =
+                new TestingEntryPoint.Builder()
+                        .setConfiguration(flinkConfig)
+                        .setDispatcherRunnerFactory(
+                                new TestingDispatcherRunnerFactory.Builder()
+                                        .setShutDownFuture(shutDownFuture)
+                                        .build())
+                        .build();
+        testingEntryPoint.startCluster();
+
+        shutDownFuture.complete(ApplicationStatus.SUCCEEDED);
+        testingEntryPoint.getTerminationFuture().join();
+
+        assertFalse(
+                "The working directory has not been deleted when the application completed successfully.",
+                workingDir.exists());
     }
 
     private CompletableFuture<ApplicationStatus> startClusterEntrypoint(

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ClusterEntrypointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ClusterEntrypointITCase.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.recovery;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.DispatcherProcess;
+import org.apache.flink.test.util.TestProcessBuilder;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.junit.Assert.assertTrue;
+
+/** Integration tests for the {@link org.apache.flink.runtime.entrypoint.ClusterEntrypoint}. */
+public class ClusterEntrypointITCase extends TestLogger {
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @Test
+    public void testWorkingDirectoryIsNotDeletedInCaseOfProcessFailure() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+        final ResourceID resourceId = ResourceID.generate();
+        final File workingDirectory =
+                ClusterEntrypointUtils.createWorkingDir(
+                        workingDirBase.getAbsolutePath(), resourceId);
+
+        final Configuration configuration = new Configuration();
+        configuration.set(
+                ClusterOptions.PROCESS_WORKING_DIR_BASE, workingDirBase.getAbsolutePath());
+        configuration.set(JobManagerOptions.JOB_MANAGER_RESOURCE_ID, resourceId.toString());
+
+        final TestProcessBuilder.TestProcess taskManagerProcess =
+                new TestProcessBuilder(
+                                DispatcherProcess.DispatcherProcessEntryPoint.class.getName())
+                        .addConfigAsMainClassArgs(configuration)
+                        .start();
+
+        boolean success = false;
+        try {
+            CommonTestUtils.waitUntilCondition(
+                    workingDirectory::exists, Deadline.fromNow(Duration.ofMinutes(1L)));
+
+            taskManagerProcess.getProcess().destroy();
+
+            taskManagerProcess.getProcess().waitFor();
+
+            assertTrue(workingDirectory.exists());
+            success = true;
+        } finally {
+            if (!success) {
+                AbstractTaskManagerProcessFailureRecoveryTest.printProcessLog(
+                        "JobManager", taskManagerProcess);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces jobmanager.resource-id to configure the resource id of the jobmanager process.
Per default it generates a random ResourceID.