### PR TITLE
[FLINK-XXXX] Use working directory as default for various components

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -295,6 +295,19 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         LOG.info("Initializing cluster services.");
 
         synchronized (lock) {
+            final ResourceID resourceId =
+                    configuration
+                            .getOptional(JobManagerOptions.JOB_MANAGER_RESOURCE_ID)
+                            .map(ResourceID::new)
+                            .orElseGet(ResourceID::generate);
+
+            LOG.debug(
+                    "Initialize cluster entrypoint {} with resource id {}.",
+                    getClass().getSimpleName(),
+                    resourceId);
+
+            ClusterEntrypointUtils.configureJobManagerWorkingDirectory(configuration, resourceId);
+
             rpcSystem = RpcSystem.load(configuration);
 
             commonRpcService =
@@ -339,19 +352,6 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             executionGraphInfoStore =
                     createSerializableExecutionGraphStore(
                             configuration, commonRpcService.getScheduledExecutor());
-
-            final ResourceID resourceId =
-                    configuration
-                            .getOptional(JobManagerOptions.JOB_MANAGER_RESOURCE_ID)
-                            .map(ResourceID::new)
-                            .orElseGet(ResourceID::generate);
-
-            LOG.debug(
-                    "Initialize cluster entrypoint {} with resource id {}.",
-                    getClass().getSimpleName(),
-                    resourceId);
-
-            ClusterEntrypointUtils.configureJobManagerWorkingDirectory(configuration, resourceId);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
@@ -218,6 +218,10 @@ public final class ClusterEntrypointUtils {
         return getTmpWorkingDir(getWorkingDirectory(configuration));
     }
 
+    public static File getBlobsWorkingDirectory(ReadableConfig configuration) {
+        return new File(getWorkingDirectory(configuration), "blobs");
+    }
+
     @Nonnull
     public static File getLocalStateWorkingDirectory(Configuration configuration) {
         final File workingDirectory = getWorkingDirectory(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ClusterOptionsInternal;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
@@ -206,14 +207,14 @@ public final class ClusterEntrypointUtils {
         return new File(workingDir, "tmp");
     }
 
-    public static File getWorkingDirectory(Configuration configuration) {
+    public static File getWorkingDirectory(ReadableConfig configuration) {
         return new File(
                 Preconditions.checkNotNull(
                         configuration.get(ClusterOptionsInternal.WORKING_DIR),
                         "The working directory has not been configured properly."));
     }
 
-    public static File getTmpWorkingDirectory(Configuration configuration) {
+    public static File getTmpWorkingDirectory(ReadableConfig configuration) {
         return getTmpWorkingDir(getWorkingDirectory(configuration));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
@@ -217,6 +217,14 @@ public final class ClusterEntrypointUtils {
         return getTmpWorkingDir(getWorkingDirectory(configuration));
     }
 
+    @Nonnull
+    public static File getLocalStateWorkingDirectory(Configuration configuration) {
+        final File workingDirectory = getWorkingDirectory(configuration);
+
+        final File localStateDir = new File(workingDirectory, "localState");
+        return localStateDir;
+    }
+
     @VisibleForTesting
     public static File getWorkingDir(String basePath, ResourceID resourceId) {
         return new File(basePath, resourceId.toString());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -36,6 +36,7 @@ import org.apache.flink.util.NetUtils;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.Optional;
 
@@ -248,11 +249,12 @@ public class TaskManagerServicesConfiguration {
             boolean localCommunicationOnly,
             TaskExecutorResourceSpec taskExecutorResourceSpec)
             throws Exception {
-        final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
         String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
         if (localStateRootDir.length == 0) {
-            // default to temp dirs.
-            localStateRootDir = tmpDirs;
+            final File localStateDir =
+                    ClusterEntrypointUtils.getLocalStateWorkingDirectory(configuration);
+
+            localStateRootDir = new String[] {localStateDir.getAbsolutePath()};
         }
 
         boolean localRecoveryMode = configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY);
@@ -281,6 +283,8 @@ public class TaskManagerServicesConfiguration {
                 CoreOptions.getParentFirstLoaderPatterns(configuration);
 
         final int numIoThreads = ClusterEntrypointUtils.getPoolSize(configuration);
+
+        final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
 
         return new TaskManagerServicesConfiguration(
                 configuration,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -305,8 +306,11 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
 
         // initialize the paths where the local RocksDB files should be stored
         if (localRocksDbDirectories == null) {
-            // initialize from the temp directories
-            initializedDbBasePaths = env.getIOManager().getSpillingDirectories();
+            initializedDbBasePaths =
+                    new File[] {
+                        ClusterEntrypointUtils.getTmpWorkingDirectory(
+                                env.getTaskManagerInfo().getConfiguration())
+                    };
         } else {
             List<File> dirs = new ArrayList<>(localRocksDbDirectories.length);
             StringBuilder errorMessage = new StringBuilder();


### PR DESCRIPTION
[FLINK-XXXX] Let LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS default to <WORKING_DIR>/localState
[FLINK-XXXX] Set state.backend.rocksdb.localdir to default to <WORKING_DIR>/tmp
[FLINK-XXXX] Let blob.storage.directory default to <WORKING_DIR>/blobs